### PR TITLE
Fix TypeError in /users endpoint when Graph API returns errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -749,14 +749,17 @@ def list_users() -> Any:
             privileged_admin_count = len(pra_assignments.get('value', [])) if pra_assignments else 0
         summary['global_admin_count'] = global_admin_count
         summary['privileged_admin_count'] = privileged_admin_count
-        # Retrieve total user count if possible
+        # Retrieve total user count if possible.  graph_request returns a
+        # string for /$count on success but a dict for HTTP 4xx/5xx error
+        # bodies (and None on auth/network failures), so guard on str before
+        # coercing.
         total_users: Optional[int] = None
         count_resp = graph_request(org, 'GET', '/users/$count', extra_headers={'ConsistencyLevel': 'eventual'})
-        try:
-            if count_resp is not None:
+        if isinstance(count_resp, str):
+            try:
                 total_users = int(count_resp)
-        except ValueError:
-            total_users = None
+            except ValueError:
+                total_users = None
         summary['total_users'] = total_users
         return render_template(
             'users.html',
@@ -898,7 +901,7 @@ def list_users() -> Any:
                     f"or startswith(givenName,'{safe_q}') or startswith(surname,'{safe_q}')"
                 )
             count_resp = graph_request(org, 'GET', '/users/$count', params=count_params, extra_headers={'ConsistencyLevel': 'eventual'})
-            if count_resp is not None:
+            if isinstance(count_resp, str):
                 total_count = int(count_resp)
                 total_pages = (total_count + page_size - 1) // page_size if total_count > 0 else 1
             else:


### PR DESCRIPTION
修复 /users?view=summary 和 /users?view=users 在 Graph API 返回错误时的 TypeError。

问题：
- graph_request() 对 4xx/5xx 响应返回 JSON dict（错误体）
- / 端点成功时返回字符串，但错误时返回 dict
- 代码直接 int(count_resp) 导致 TypeError

修复：
- app.py:753-759 (summary 视图): 用 isinstance(count_resp, str) 守卫
- app.py:900-908 (users 视图): 用 isinstance(count_resp, str) 守卫
- 新增 .gitignore: 忽略 .venv/, config.json, __pycache__/
- 新增 CLAUDE.md: 项目架构文档

验证：
- 用真实租户凭据测试 /users?view=summary → 200 OK
- 测试 /users?view=users 分页 → 200 OK
- 审计所有 40+ 处 graph_request 调用点 → 其他均安全